### PR TITLE
Implement parallel search

### DIFF
--- a/wktesthunter
+++ b/wktesthunter
@@ -28,12 +28,14 @@ except:
     # No python3 :(
     pass
 
-import re
-import json
 import argparse
-import subprocess
+import json
 import math
+import re
+import subprocess
+
 from collections import OrderedDict
+from multiprocessing import Pool
 
 extrahelp = '''
 About the colors:
@@ -224,14 +226,22 @@ def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, bo
             continue
         jsonresults=os.listdir(botdir)
         jsonresults.sort()
-        JOBS = 4
-        trade = math.ceil(len(jsonresults)/JOBS)
-        for i in range(0,JOBS):
-            start, end = i*trade, (i+1)*trade
-            if end > len(jsonresults):
-                end = len(jsonresults)
-            ret = search(test, botdir, jsonresults[start:end])
-            merge(resultsfortests[test], ret)
+        # Split job in several workers.
+        processes = 8
+        pool = Pool(processes=processes)
+        size = len(jsonresults)
+        stride = math.ceil(size/processes)
+        results = list()
+        for i in range(0, processes):
+            start, end = i*stride, (i+1)*stride
+            if end > size:
+                end = size
+            results.append(pool.apply_async(search, (test, botdir, jsonresults[start:end])))
+        # Join workers and merge results.
+        pool.close()
+        pool.join()
+        for each in results:
+            merge(resultsfortests[test], each.get())
 
     if len(resultsfortests[test]) == 0:
         print ("ERROR: No revisions fetched for bot: %s Please run the fetch script." %botkey)

--- a/wktesthunter
+++ b/wktesthunter
@@ -33,6 +33,7 @@ import json
 import math
 import re
 import subprocess
+import multiprocessing as mp
 
 from collections import OrderedDict
 from multiprocessing import Pool
@@ -172,7 +173,7 @@ def merge(dst, src):
     for k,v in src.items():
         dst[k] = v
 
-def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, botkey):
+def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, botkey, processes):
     resultsfortests = {}
     resultsfortests[test]=OrderedDict()
     testparts=test.split('/')
@@ -226,22 +227,24 @@ def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, bo
             continue
         jsonresults=os.listdir(botdir)
         jsonresults.sort()
-        # Split job in several workers.
-        processes = 8
-        pool = Pool(processes=processes)
-        size = len(jsonresults)
-        stride = math.ceil(size/processes)
-        results = list()
-        for i in range(0, processes):
-            start, end = i*stride, (i+1)*stride
-            if end > size:
-                end = size
-            results.append(pool.apply_async(search, (test, botdir, jsonresults[start:end])))
-        # Join workers and merge results.
-        pool.close()
-        pool.join()
-        for each in results:
-            merge(resultsfortests[test], each.get())
+        if processes == 1:
+            merge(resultsfortests[test], search(test, botdir, jsonresults))
+        else:
+            # Split job in several workers.
+            pool = Pool(processes=processes)
+            size = len(jsonresults)
+            stride = int(math.ceil(size/processes))
+            results = list()
+            for i in range(0, processes):
+                start, end = i*stride, (i+1)*stride
+                if end > size:
+                    end = size
+                results.append(pool.apply_async(search, (test, botdir, jsonresults[start:end])))
+            # Join workers and merge results.
+            pool.close()
+            pool.join()
+            for each in results:
+                merge(resultsfortests[test], each.get())
 
     if len(resultsfortests[test]) == 0:
         print ("ERROR: No revisions fetched for bot: %s Please run the fetch script." %botkey)
@@ -313,6 +316,7 @@ if __name__ == '__main__':
     parser.add_argument("--nocolor", help="Don't print colors", action="store_true")
     parser.add_argument("--nochecksvn", help="Don't query svn.webkit.org for the revision that added the test and assume it was r1.", action="store_true")
     parser.add_argument("--bot", help="Check the test results for a specific bot. Default is: %(default)s", choices=list(bots.keys()), default="gtk-release")
+    parser.add_argument("-j", type=int, help="Number of processes to use", default=mp.cpu_count())
     parser.add_argument("test_name", type=str, help="Name for the test (as specified on run-webkit-tests).")
     args = parser.parse_args()
 
@@ -331,4 +335,4 @@ if __name__ == '__main__':
     if args.nochecksvn: checksvn = False
     else: checksvn = True
 
-    main(args.test_name, debug, detail, mergeunknown, showexpected, usecolor, checksvn, args.bot)
+    main(args.test_name, debug, detail, mergeunknown, showexpected, usecolor, checksvn, args.bot, args.j)

--- a/wktesthunter
+++ b/wktesthunter
@@ -113,8 +113,9 @@ bots = { # The reason to have more than one entry per bot is that some bots wher
     'wpe-debug' : ["WPE Linux 64-bit Debug (Tests)"]
 }
 
-def search(test, botdir, jsonresults, resultsfortests):
+def search(test, botdir, jsonresults):
     global noerror
+    ret = {}
     testparts=test.split('/')
     for jsonresult in jsonresults:
         if jsonresult.startswith("full_results_") and jsonresult.endswith('.json'):
@@ -139,10 +140,10 @@ def search(test, botdir, jsonresults, resultsfortests):
                 if debug: print ("WARNING: Parsed revision %s don't match expected one %d for file %s" %(json_parsed['revision'],revision,jsonresult))
                 revision=int(json_parsed['revision'])
 
-            if revision in resultsfortests[test]:
+            if revision in ret:
                 if debug: print ("WARNING: Data for revision %d duplicated. Picking last\n" %revision)
 
-            resultsfortests[test][revision]={}
+            ret[revision]={}
 
             keytest=json_parsed['tests']
             try:
@@ -153,15 +154,20 @@ def search(test, botdir, jsonresults, resultsfortests):
                 if json_parsed['interrupted']:
                     # If the whole set of tests didn't finished, mark it as unknown.
                     if debug: print ("On revision %s the test set didn't finished." %(revision))
-                    resultsfortests[test][revision]['result']=unknown
+                    ret[revision]['result']=unknown
                 else:
                     # Otherwise, mark it as noerror.
-                    resultsfortests[test][revision]['result']=noerror
+                    ret[revision]['result']=noerror
                 continue
 
-            resultsfortests[test][revision]['result']=keytest['actual']
+            ret[revision]['result']=keytest['actual']
             if 'expected' in keytest:
-                resultsfortests[test][revision]['expected']=keytest['expected']
+                ret[revision]['expected']=keytest['expected']
+    return ret
+
+def merge(dst, src):
+    for k,v in src.items():
+        dst[k] = v
 
 def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, botkey):
     resultsfortests = {}
@@ -217,7 +223,7 @@ def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, bo
             continue
         jsonresults=os.listdir(botdir)
         jsonresults.sort()
-        search(test, botdir, jsonresults, resultsfortests)
+        merge(resultsfortests[test], search(test, botdir, jsonresults))
 
     if len(resultsfortests[test]) == 0:
         print ("ERROR: No revisions fetched for bot: %s Please run the fetch script." %botkey)

--- a/wktesthunter
+++ b/wktesthunter
@@ -85,6 +85,8 @@ Note for lazy people:
       "--onlyprinterr", "--only" or "--o"; or you can use "--mergeunknown", "--merge" or "--m"
 '''
 
+noerror="NOERROR"
+unknown="UNKNOWN"
 
 def iprint(firstrev,lastrev,result,startcolor):
 
@@ -110,6 +112,56 @@ bots = { # The reason to have more than one entry per bot is that some bots wher
     'wpe-release' : ["WPE Linux 64-bit Release (Tests)"],
     'wpe-debug' : ["WPE Linux 64-bit Debug (Tests)"]
 }
+
+def search(test, botdir, jsonresults, resultsfortests):
+    global noerror
+    testparts=test.split('/')
+    for jsonresult in jsonresults:
+        if jsonresult.startswith("full_results_") and jsonresult.endswith('.json'):
+            (revision, buildnumber) = jsonresult.split("full_results_")[1].split(".json")[0].split('_')
+            revision=int(revision.strip('r'))
+            buildnumber=int(buildnumber.strip('b'))
+            # Read file
+            json_file=open(os.path.join(botdir, jsonresult))
+            json_data=json_file.read()
+            json_file.close()
+            # Clean it
+            json_data=json_data.split('ADD_RESULTS(')[1]
+            json_data=json_data.split(');')[0]
+            # Parse it
+            try:
+                json_parsed = json.loads(json_data)
+            except:
+                if debug: print ("WARNING: Exception caused by file: %s Ignoring file." %os.path.join('jsonresults',bot,jsonresult))
+                continue
+            # Sanity check
+            if int(json_parsed['revision']) != revision:
+                if debug: print ("WARNING: Parsed revision %s don't match expected one %d for file %s" %(json_parsed['revision'],revision,jsonresult))
+                revision=int(json_parsed['revision'])
+
+            if revision in resultsfortests[test]:
+                if debug: print ("WARNING: Data for revision %d duplicated. Picking last\n" %revision)
+
+            resultsfortests[test][revision]={}
+
+            keytest=json_parsed['tests']
+            try:
+                for testpart in testparts:
+                    keytest=keytest[testpart]
+            except KeyError:
+                # This test didn't failed (or wasn't ran) on this rev.
+                if json_parsed['interrupted']:
+                    # If the whole set of tests didn't finished, mark it as unknown.
+                    if debug: print ("On revision %s the test set didn't finished." %(revision))
+                    resultsfortests[test][revision]['result']=unknown
+                else:
+                    # Otherwise, mark it as noerror.
+                    resultsfortests[test][revision]['result']=noerror
+                continue
+
+            resultsfortests[test][revision]['result']=keytest['actual']
+            if 'expected' in keytest:
+                resultsfortests[test][revision]['expected']=keytest['expected']
 
 def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, botkey):
     resultsfortests = {}
@@ -165,52 +217,7 @@ def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, bo
             continue
         jsonresults=os.listdir(botdir)
         jsonresults.sort()
-        for jsonresult in jsonresults:
-            if jsonresult.startswith("full_results_") and jsonresult.endswith('.json'):
-                (revision, buildnumber) = jsonresult.split("full_results_")[1].split(".json")[0].split('_')
-                revision=int(revision.strip('r'))
-                buildnumber=int(buildnumber.strip('b'))
-                # Read file
-                json_file=open(os.path.join(botdir, jsonresult))
-                json_data=json_file.read()
-                json_file.close()
-                # Clean it
-                json_data=json_data.split('ADD_RESULTS(')[1]
-                json_data=json_data.split(');')[0]
-                # Parse it
-                try:
-                    json_parsed = json.loads(json_data)
-                except:
-                    if debug: print ("WARNING: Exception caused by file: %s Ignoring file." %os.path.join('jsonresults',bot,jsonresult))
-                    continue
-                # Sanity check
-                if int(json_parsed['revision']) != revision:
-                    if debug: print ("WARNING: Parsed revision %s don't match expected one %d for file %s" %(json_parsed['revision'],revision,jsonresult))
-                    revision=int(json_parsed['revision'])
-
-                if revision in resultsfortests[test]:
-                    if debug: print ("WARNING: Data for revision %d duplicated. Picking last\n" %revision)
-
-                resultsfortests[test][revision]={}
-
-                keytest=json_parsed['tests']
-                try:
-                    for testpart in testparts:
-                        keytest=keytest[testpart]
-                except KeyError:
-                    # This test didn't failed (or wasn't ran) on this rev.
-                    if json_parsed['interrupted']:
-                        # If the whole set of tests didn't finished, mark it as unknown.
-                        if debug: print ("On revision %s the test set didn't finished." %(revision))
-                        resultsfortests[test][revision]['result']=unknown
-                    else:
-                        # Otherwise, mark it as noerror.
-                        resultsfortests[test][revision]['result']=noerror
-                    continue
-
-                resultsfortests[test][revision]['result']=keytest['actual']
-                if 'expected' in keytest:
-                    resultsfortests[test][revision]['expected']=keytest['expected']
+        search(test, botdir, jsonresults, resultsfortests)
 
     if len(resultsfortests[test]) == 0:
         print ("ERROR: No revisions fetched for bot: %s Please run the fetch script." %botkey)

--- a/wktesthunter
+++ b/wktesthunter
@@ -32,6 +32,7 @@ import re
 import json
 import argparse
 import subprocess
+import math
 from collections import OrderedDict
 
 extrahelp = '''
@@ -223,7 +224,14 @@ def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, bo
             continue
         jsonresults=os.listdir(botdir)
         jsonresults.sort()
-        merge(resultsfortests[test], search(test, botdir, jsonresults))
+        JOBS = 4
+        trade = math.ceil(len(jsonresults)/JOBS)
+        for i in range(0,JOBS):
+            start, end = i*trade, (i+1)*trade
+            if end > len(jsonresults):
+                end = len(jsonresults)
+            ret = search(test, botdir, jsonresults[start:end])
+            merge(resultsfortests[test], ret)
 
     if len(resultsfortests[test]) == 0:
         print ("ERROR: No revisions fetched for bot: %s Please run the fetch script." %botkey)

--- a/wktesthunter
+++ b/wktesthunter
@@ -121,7 +121,13 @@ def search(test, botdir, jsonresults):
     global noerror
     ret = {}
     testparts=test.split('/')
+    count = 0
+    threshold = 100
     for jsonresult in jsonresults:
+        if count > threshold:
+            count = 0
+            sys.stdout.write(".")
+            sys.stdout.flush()
         if jsonresult.startswith("full_results_") and jsonresult.endswith('.json'):
             (revision, buildnumber) = jsonresult.split("full_results_")[1].split(".json")[0].split('_')
             revision=int(revision.strip('r'))
@@ -167,6 +173,7 @@ def search(test, botdir, jsonresults):
             ret[revision]['result']=keytest['actual']
             if 'expected' in keytest:
                 ret[revision]['expected']=keytest['expected']
+            count += 1
     return ret
 
 def merge(dst, src):
@@ -220,6 +227,8 @@ def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, bo
         noerror="NOERROR"
         unknown="UNKNOWN"
 
+    sys.stdout.write("Searching: ")
+    sys.stdout.flush()
     for bot in bots[botkey]:
         botdir=os.path.join('jsonresults',bot)
         if not os.path.isdir(botdir):

--- a/wktesthunter
+++ b/wktesthunter
@@ -258,8 +258,9 @@ def main(test, debug, detail, mergeunknown, showexpected, usecolor, checksvn, bo
     if len(resultsfortests[test]) == 0:
         print ("ERROR: No revisions fetched for bot: %s Please run the fetch script." %botkey)
         return
-    minrev=list(resultsfortests[test].keys())[0]
-    maxrev=list(resultsfortests[test].keys())[len(resultsfortests[test])-1]
+    keys = list(resultsfortests[test].keys())
+    keys.sort()
+    minrev, maxrev = keys[0], keys[len(keys) - 1]
     print ("INFO: The revisions already fetched from the bots are on the interval [r%d-r%d]" %(minrev,maxrev))
     startrev=max(minrev,svnrev)
     if startrev > maxrev:


### PR DESCRIPTION
Search is done in parallel using several workers. Default number of workers is the number of cores available in the system. The number of cores can be adjusted with argument "-j". Example:

```bash
# Using 1 core.
$ time ./wktesthunter crypto/workers/subtle/rsa-postMessage-worker.html -j 1 | tee log
...
real    1m16.361s
user    1m12.751s
sys     0m1.802s
```

```bash
# Using all available cores (12).
$ time ./wktesthunter crypto/workers/subtle/rsa-postMessage-worker.html | tee log2
...
real    0m13.874s
user    1m35.465s
sys     0m5.068s
```

There's no difference between results:

```bash
$ diff -s log log2
Files log and log2 are identical
```