### PR TITLE
Update bots names

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -24,13 +24,13 @@ webkitresultsurl="http://build.webkit.org/results"
 # We fetch all the data from the actual test bot as also the past ones, to have a complete history
 declare -A webkitbots_map
 webkitbots_map=(
-   ["gtk-release-old"]="GTK Linux 64-bit Release"
-   ["gtk-release-wk2"]="GTK Linux 64-bit Release WK2 (Tests)"
-   ["gtk-release"]="GTK Linux 64-bit Release (Tests)"
-   ["gtk-debug"]="GTK Linux 64-bit Debug (Tests)"
-   ["gtk-release-wayland"]="GTK Linux 64-bit Release Wayland (Tests)"
-   ["wpe-release"]="WPE Linux 64-bit Release (Tests)"
-   ["wpe-debug"]="WPE Linux 64-bit Debug (Tests)"
+   ["gtk-release-old"]="GTK-Linux-64-bit-Release"
+   ["gtk-release-wk2"]="GTK-Linux-64-bit-Release-WK2-Tests"
+   ["gtk-release"]="GTK-Linux-64-bit-Release-Tests"
+   ["gtk-debug"]="GTK-Linux-64-bit-Debug-Tests"
+   ["gtk-release-wayland"]="GTK-Linux-64-bit-Release-Wayland-Tests"
+   ["wpe-release"]="WPE-Linux-64-bit-Release-Tests"
+   ["wpe-debug"]="WPE-Linux-64-bit-Debug-Tests"
 )
 webkitbots_keys=()
 for each in "${!webkitbots_map[@]}"; do

--- a/wktesthunter
+++ b/wktesthunter
@@ -112,11 +112,11 @@ def iprint(firstrev,lastrev,result,startcolor):
 
 
 bots = { # The reason to have more than one entry per bot is that some bots where renamed along the history.
-    'gtk-release' : ["GTK Linux 64-bit Release", "GTK Linux 64-bit Release WK2 (Tests)", "GTK Linux 64-bit Release (Tests)"],
-    'gtk-debug' : ["GTK Linux 64-bit Debug (Tests)"],
-    'gtk-release-wayland' : ["GTK Linux 64-bit Release Wayland (Tests)"],
-    'wpe-release' : ["WPE Linux 64-bit Release (Tests)"],
-    'wpe-debug' : ["WPE Linux 64-bit Debug (Tests)"]
+    'gtk-release' : ["GTK-Linux-64-bit-Release", "GTK-Linux-64-bit-Release-WK2-Tests", "GTK-Linux-64-bit-Release-Tests"],
+    'gtk-debug' : ["GTK-Linux-64-bit-Debug-Tests"],
+    'gtk-release-wayland' : ["GTK-Linux-64-bit-Release-Wayland-Tests"],
+    'wpe-release' : ["WPE-Linux-64-bit-Release-Tests"],
+    'wpe-debug' : ["WPE-Linux-64-bit-Debug-Tests"]
 }
 
 


### PR DESCRIPTION
Recently build.webkit.org updated its buildbot version to 0.9 and the names of the bots changed https://trac.webkit.org/changeset/268154/webkit.

Scripts need to update the names of the bots accordingly.